### PR TITLE
salesリポジトリにhorizonを入れるにあたり、pcntlが必要なため

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN deps='\
     && sudo apt install -y -qq --no-install-recommends $deps \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo gem install bundler hub --no-document \
-    && sudo docker-php-ext-install pdo_pgsql soap \
+    && sudo docker-php-ext-install pdo_pgsql pcntl \
     && composer global require hirak/prestissimo
 


### PR DESCRIPTION
salesリポジトリにhorizonを入れたいが、pcntlが必要でcircleciのbuildに失敗するため、イメージに書き込みました。

ついでにsalesforceとの連携に必要だったsoapが不要になったため、削除。